### PR TITLE
Add swa cli config

### DIFF
--- a/swa-cli.config.json
+++ b/swa-cli.config.json
@@ -1,0 +1,8 @@
+{
+    "configurations": {
+        "app": {
+            "context": "http://localhost:3000",
+            "run": "npx nuxt"
+        }
+    }
+}


### PR DESCRIPTION
Until we add dedicated Nuxt.js support into the extension detection logic, a `swa-cli.config.json` file is needed to tell the extension how to debug the app.

I was able to hit breakpoints in the api, but not in Vue. I will have to do more work on getting breakpoints to work in Vue. Debugging Vue has been somewhat hard and on my todo list to figure out how to get working consistently.

Once added you should see these options in the dropdowns:

![image](https://user-images.githubusercontent.com/12476526/149029137-0264fc8b-fdef-4321-9295-d0477a40f8e9.png)
![image](https://user-images.githubusercontent.com/12476526/149029160-7a9ef3d2-6728-48f6-bbaa-8cdf01003740.png)
